### PR TITLE
fix(ci-checks): mount postgres volume at /var/lib/postgresql

### DIFF
--- a/apps/forgejo/docker-compose.ci.yml
+++ b/apps/forgejo/docker-compose.ci.yml
@@ -22,7 +22,7 @@ services:
     networks:
       - 'backend'
     volumes:
-      - 'forgejo-db:/var/lib/postgresql/data'
+      - 'forgejo-db:/var/lib/postgresql'
     environment:
       POSTGRES_USER: 'forgejo'
       POSTGRES_DB: 'forgejo'

--- a/apps/gotify/docker-compose.ci.yml
+++ b/apps/gotify/docker-compose.ci.yml
@@ -17,7 +17,7 @@ services:
     networks:
       - 'backend'
     volumes:
-      - 'gotify-db:/var/lib/postgresql/data'
+      - 'gotify-db:/var/lib/postgresql'
     environment:
       POSTGRES_USER: 'gotify'
       POSTGRES_DB: 'gotify'

--- a/apps/keycloak/docker-compose.ci.yml
+++ b/apps/keycloak/docker-compose.ci.yml
@@ -21,7 +21,7 @@ services:
     networks:
       - 'backend'
     volumes:
-      - 'keycloak-db:/var/lib/postgresql/data'
+      - 'keycloak-db:/var/lib/postgresql'
     environment:
       POSTGRES_USER: 'keycloak'
       POSTGRES_DB: 'keycloak'

--- a/apps/miniflux/docker-compose.ci.yml
+++ b/apps/miniflux/docker-compose.ci.yml
@@ -20,7 +20,7 @@ services:
     networks:
       - 'backend'
     volumes:
-      - 'miniflux-db:/var/lib/postgresql/data'
+      - 'miniflux-db:/var/lib/postgresql'
     environment:
       POSTGRES_USER: 'miniflux'
       POSTGRES_DB: 'miniflux'

--- a/apps/pocket-id/docker-compose.ci.yml
+++ b/apps/pocket-id/docker-compose.ci.yml
@@ -18,7 +18,7 @@ services:
     networks:
       - 'backend'
     volumes:
-      - 'pocket-id-db:/var/lib/postgresql/data'
+      - 'pocket-id-db:/var/lib/postgresql'
     environment:
       POSTGRES_USER: 'pocket-id'
       POSTGRES_DB: 'pocket-id'

--- a/apps/wallabag/docker-compose.ci.yml
+++ b/apps/wallabag/docker-compose.ci.yml
@@ -23,7 +23,7 @@ services:
     networks:
       - 'backend'
     volumes:
-      - 'wallabag-db:/var/lib/postgresql/data'
+      - 'wallabag-db:/var/lib/postgresql'
     environment:
       POSTGRES_USER: 'wallabag'
       POSTGRES_DB: 'wallabag'


### PR DESCRIPTION
The postgres 18+ image errors out when data is detected at the legacy /var/lib/postgresql/data mount point. The alpine variant had a latent bug where this check did not fire, which is why CI kept passing until docker-library/postgres@3b6b5fc was rebuilt into postgres:18.3-alpine.